### PR TITLE
Fix errors and problems

### DIFF
--- a/lib/admin_page.dart
+++ b/lib/admin_page.dart
@@ -512,13 +512,13 @@ class _AdminPageState extends State<AdminPage> {
         actions: [
           IconButton(
             icon: const Icon(Icons.inventory),
-            onPressed: () => Navigator.pushNamed(context, '/blood_inventory'),
+            onPressed: () => Navigator.pushNamed(context, '/blood-inventory'),
             tooltip: 'Blood Inventory',
           ),
           IconButton(
             icon: const Icon(Icons.notifications),
             onPressed: () =>
-                Navigator.pushNamed(context, '/notification_management'),
+                Navigator.pushNamed(context, '/notification-management'),
             tooltip: 'Notifications',
           ),
           IconButton(
@@ -773,7 +773,7 @@ class _AdminPageState extends State<AdminPage> {
                 ),
                 ElevatedButton.icon(
                   onPressed: () =>
-                      Navigator.pushNamed(context, '/blood_inventory'),
+                      Navigator.pushNamed(context, '/blood-inventory'),
                   icon: const Icon(Icons.inventory),
                   label: const Text('Manage Inventory'),
                   style: ElevatedButton.styleFrom(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -138,11 +138,11 @@ class NavigationUtils {
   }
 
   static void navigateToBloodInventory(BuildContext context) {
-    Navigator.pushNamed(context, '/blood_inventory');
+    Navigator.pushNamed(context, '/blood-inventory');
   }
 
   static void navigateToNotificationManagement(BuildContext context) {
-    Navigator.pushNamed(context, '/notifications');
+    Navigator.pushNamed(context, '/notification-management');
   }
 
   static Future<void> logout(BuildContext context) async {


### PR DESCRIPTION
Corrected navigation route names to resolve runtime errors.

Previously, navigation calls in `lib/admin_page.dart` and `lib/main.dart` used incorrect route names (e.g., `/blood_inventory` instead of `/blood-inventory`, and `/notifications` instead of `/notification-management`). This caused `route-not-found` exceptions. This PR aligns all navigation calls with the actual routes defined in `MaterialApp.routes`.

---
<a href="https://cursor.com/background-agent?bcId=bc-34a225af-988b-4f9e-87c3-02b659c87c98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34a225af-988b-4f9e-87c3-02b659c87c98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>